### PR TITLE
Add a way to get all opencl devices

### DIFF
--- a/build-sycl.cmd
+++ b/build-sycl.cmd
@@ -20,8 +20,9 @@ set CUDNN_PATH=%CUDA_PATH%
 set OPENBLAS_PATH=C:\OpenBLAS
 set MKL_PATH=C:\Program Files (x86)\Intel\oneAPI\mkl\latest\
 set DNNL_PATH=C:\Program Files (x86)\Intel\oneAPI\dnnl\latest\cpu_iomp
-set OPENCL_LIB_PATH=%CUDA_PATH%\lib\x64
-set OPENCL_INCLUDE_PATH=%CUDA_PATH%\include
+set SYCL_PATH=C:\Program Files (x86)\Intel\oneAPI\compiler\2025.0
+set OPENCL_LIB_PATH=%SYCL_PATH%\lib
+set OPENCL_INCLUDE_PATH=%SYCL_PATH%\include\sycl\CL
 
 rem 3. In most cases you won't need to change anything further down.
 echo Deleting build directory:
@@ -48,7 +49,7 @@ meson setup build --buildtype release -Ddx=%DX12% -Dcudnn=%CUDNN% -Dplain_cuda=%
 -Dopencl=%OPENCL% -Dblas=%BLAS% -Dmkl=%MKL% -Dopenblas=%OPENBLAS% -Ddnnl=%DNNL% -Dgtest=%TEST% ^
 -Dcudnn_include="%CUDNN_INCLUDE_PATH%" -Dcudnn_libdirs="%CUDNN_LIB_PATH%" ^
 -Dmkl_include="%MKL_PATH%\include" -Dmkl_libdirs="%MKL_PATH%\lib\intel64" -Ddnnl_dir="%DNNL_PATH%" ^
--Dopencl_libdirs="%OPENCL_LIB_PATH%" -Dopencl_include="%OPENCL_INCLUDE_PATH%" ^
+-Dpopcnt=false -Dopencl_libdirs="%OPENCL_LIB_PATH%" -Dopencl_include="%OPENCL_INCLUDE_PATH%" ^
 -Dopenblas_include="%OPENBLAS_PATH%\include" -Dopenblas_libdirs="%OPENBLAS_PATH%\lib" ^
 -Ddefault_library=static -Dsycl=%SYCL% -Db_vscrt=md
 

--- a/meson.build
+++ b/meson.build
@@ -38,7 +38,7 @@ if cc.get_id() == 'clang'
 endif
 if cc.get_id() != 'msvc'
   if get_option('buildtype') == 'release'
-    add_project_arguments(cc.get_supported_arguments(['-march=native']), language : 'cpp')
+   #add_project_arguments(cc.get_supported_arguments(['-march=native']), language : 'cpp')
   endif
 endif
 if cc.get_id() == 'msvc'

--- a/src/neural/sycl/inputs_outputs.h
+++ b/src/neural/sycl/inputs_outputs.h
@@ -108,9 +108,9 @@ struct InputsOutputs {
   void** offset_pointers_ = nullptr;
   void** head_offset_pointers_ = nullptr;
 
-  // cuda stream used to run the network
+  // sycl queue used to run the network
   sycl::queue& q_ct1;
 };
 
-}  // namespace cudnn_backend
+}  // namespace sycldnn_backend
 }  // namespace lczero

--- a/src/neural/sycl/network_sycl.cc.dp.cpp
+++ b/src/neural/sycl/network_sycl.cc.dp.cpp
@@ -201,13 +201,14 @@ class SyclNetwork : public Network {
                  nf.network() == NF::NETWORK_ATTENTIONBODY_WITH_MULTIHEADFORMAT;
 
     max_batch_size_ = options.GetOrDefault<int>("max_batch", 1024);
+    std::string device_plat_ = options.GetOrDefault<std::string>("platform", "OpenCL");
     
     // Get all the available platforms
     auto platforms = sycl::platform::get_platforms();
     
     // Look only for OpenCL platforms
     for (const auto& platform : platforms) {
-      if (platform.get_info<sycl::info::platform::name>().find("OpenCL") != std::string::npos) {
+      if (platform.get_info<sycl::info::platform::name>().find(device_plat_) != std::string::npos) {
             auto platform_devices = platform.get_devices();
             devices.insert(devices.end(), platform_devices.begin(), platform_devices.end());
         }
@@ -224,7 +225,7 @@ class SyclNetwork : public Network {
     sycl::context context{device_};
       
     // Get the number of compute units(execution units).
-    compute_units_ = device_.get_info<sycl::info::device::max_compute_units>();
+    compute_units_ = (int)device_.get_info<sycl::info::device::max_compute_units>();
 
     if (gpu_id_ >= (int)devices.size())
       throw Exception("Invalid GPU Id: " + std::to_string(gpu_id_));

--- a/src/neural/sycl/network_sycl.cc.dp.cpp
+++ b/src/neural/sycl/network_sycl.cc.dp.cpp
@@ -925,6 +925,7 @@ class SyclNetwork : public Network {
   // Check if device is the cpu for thread handling.
   bool IsCpu() const override { return device_.is_cpu(); }
   
+  // For now its just 2 threads will add for multiple gpu's. 
   int GetThreads() const override { return 2 /*+ total_gpus_*/; }
   
   int GetMiniBatchSize() const override {

--- a/src/neural/sycl/network_sycl.cc.dp.cpp
+++ b/src/neural/sycl/network_sycl.cc.dp.cpp
@@ -944,10 +944,10 @@ class SyclNetwork : public Network {
   bool IsCpu() const override { return device_.is_cpu(); }
   
   // 2 threads for cpu and 1 + total_gpu's for the multiple gpu's. 
-  int GetThreads() const override { return device_.is_gpu() ? 1 + total_gpus_ : 1; }
+  int GetThreads() const override { return device_.is_cpu() ? 1 : 1 + total_gpus_; }
   
   int GetMiniBatchSize() const override {
-     if (device_.is_cpu()) { return 7; }
+     if (device_.is_cpu()) { return 47; }
     // Simple heuristic that seems to work for a wide range of GPUs.
     return 2 * compute_units_;
   }


### PR DESCRIPTION
- So in this pr I've added context so each queue has context of on which device its running in case of multitiple sycl ```gpu_devices```.
- Enhancements which make it easier to get relevant device information.
- Also we skip anydevice thats not opencl for now, will be simplified away later. 